### PR TITLE
Enable Travis testing under Node v0.11.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
   - "0.10"
+  - "0.11"
 env:
   - NACL_SRC=nacl.min.js
   - NACL_SRC=nacl-fast.min.js


### PR DESCRIPTION
Base64 bug in Node v0.11.13 prevented us from enabling it, but now v0.11.14 fixed it. Did Travis CI update the version?
