### PR TITLE
(#75) - Reduce browserify build size

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,5 +60,9 @@
     "tape": "2.x.x",
     "testling": "1.x.x",
     "uglify-js": "2.x.x"
+  },
+  "browser": {
+    "buffer": false,
+    "crypto": false
   }
 }


### PR DESCRIPTION
by excluding crypto and buffer modules, which aren't used in the browser anyway.

This reduces the build size for about 470k.