### PR TITLE
Added the name of the license

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "signatures"
   ],
   "author": "TweetNaCl-js contributors",
-  "license": "SEE LICENSE IN COPYING.txt",
+  "license": "CC0",
   "bugs": {
     "url": "https://github.com/dchest/tweetnacl-js/issues"
   },


### PR DESCRIPTION
I created [legally](http://github.com/franciscop/legally) and this is one of the few packages that stands out for not having the short name for the license int he package. I added it. It's also not normal to put it in `COPYING.txt`, normally it goes into `LICENSE.txt`, but that is handled with my library.