### PR TITLE
Typings: secretbox.open can return false

### DIFF
--- a/nacl.d.ts
+++ b/nacl.d.ts
@@ -18,7 +18,7 @@ declare namespace nacl {
 
     export interface secretbox {
         (msg: Uint8Array, nonce: Uint8Array, key: Uint8Array): Uint8Array;
-        open(box: Uint8Array, nonce: Uint8Array, key: Uint8Array): Uint8Array;
+        open(box: Uint8Array, nonce: Uint8Array, key: Uint8Array): Uint8Array | false;
         readonly keyLength: number;
         readonly nonceLength: number;
         readonly overheadLength: number;
@@ -33,7 +33,7 @@ declare namespace nacl {
 
     namespace box {
         export interface open {
-            (msg: Uint8Array, nonce: Uint8Array, publicKey: Uint8Array, secretKey: Uint8Array): Uint8Array;
+            (msg: Uint8Array, nonce: Uint8Array, publicKey: Uint8Array, secretKey: Uint8Array): Uint8Array | false;
             after(box: Uint8Array, nonce: Uint8Array, key: Uint8Array): Uint8Array;
         }
 


### PR DESCRIPTION
Here:

```javascript
nacl.secretbox.open = function(box, nonce, key) {
  // ...
  if (c.length < 32) return false;
  if (crypto_secretbox_open(m, c, c.length, nonce, key) !== 0) return false;
  // ...
};
```

And here:

```javascript
nacl.box.open = function(msg, nonce, publicKey, secretKey) {
  // ...
  return nacl.secretbox.open(msg, nonce, k);
};
```

Not sure if `box.after` is also affected.