### PR TITLE
README: added link to tweetnacl-sealed-box

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,6 +468,7 @@ Third-party libraries based on TweetNaCl.js
 * [forward-secrecy](https://github.com/alax/forward-secrecy) — Axolotl ratchet implementation
 * [nacl-stream](https://github.com/dchest/nacl-stream-js) - streaming encryption
 * [tweetnacl-auth-js](https://github.com/dchest/tweetnacl-auth-js) — implementation of [`crypto_auth`](http://nacl.cr.yp.to/auth.html)
+* [tweetnacl-sealed-box](https://github.com/whs/tweetnacl-sealed-box) — implementation of [`sealed boxes`](https://download.libsodium.org/doc/public-key_cryptography/sealed_boxes.html)
 * [chloride](https://github.com/dominictarr/chloride) - unified API for various NaCl modules
 
 


### PR DESCRIPTION
I've implemented [libsodium sealed box](https://download.libsodium.org/doc/public-key_cryptography/sealed_boxes.html) support in [another package](github.com/whs/tweetnacl-sealed-box). This PR adds a link to that package.