### PR TITLE
Update documentation to reflect Buffer constructor deprecation in Node

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,10 @@ packages.
 In Node.js v4 and later `Buffer` objects are backed by `Uint8Array`s, so you
 can freely pass them to TweetNaCl.js functions as arguments. The returned
 objects are still `Uint8Array`s, so if you need `Buffer`s, you'll have to
-convert them manually; make sure to convert using copying: `new Buffer(array)`,
-instead of sharing: `new Buffer(array.buffer)`, because some functions return
-subarrays of their buffers.
+convert them manually; make sure to convert using copying: `Buffer.from(array)`
+(or `new Buffer(array)` in Node.js v4 or earlier), instead of sharing:
+`Buffer.from(array.buffer)` (or `new Buffer(array.buffer)` Node 4 or earlier),
+because some functions return subarrays of their buffers.
 
 
 ### Public-key authenticated encryption (box)


### PR DESCRIPTION
Buffer constructors have been deprecated in Node since v6, and as of v10 will emit a warning if they're used outside of `node_modules`. More info here: https://nodesource.com/blog/understanding-the-buffer-deprecation-in-node-js-10/

------------------------------------------------------------------------------

    I dedicate any and all copyright interest in this software to the
    public domain. I make this dedication for the benefit of the public at
    large and to the detriment of my heirs and successors. I intend this
    dedication to be an overt act of relinquishment in perpetuity of all
    present and future rights to this software under copyright law.

    Anyone is free to copy, modify, publish, use, compile, sell, or
    distribute this software, either in source code form or as a compiled
    binary, for any purpose, commercial or non-commercial, and by any
    means.
