### PR TITLE
Remove useless assignment

### DIFF
--- a/nacl.js
+++ b/nacl.js
@@ -833,7 +833,6 @@ function crypto_sign_open(m, sm, n, pk) {
   var p = [gf(), gf(), gf(), gf()],
       q = [gf(), gf(), gf(), gf()];
 
-  mlen = -1;
   if (n < 64) return -1;
 
   if (unpackneg(q, pk)) return -1;


### PR DESCRIPTION
This PR removes a useless assignment as the method always return either `-1`or the value of `n`.