### PR TITLE
Sealed Boxes

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,11 +1,12 @@
 List of TweetNaCl.js authors
 ============================
 
-    Format: Name (GitHub username or URL)
+    Format: Name (GitHub username and URL)
 
-* Dmitry Chestnykh (@dchest)
-* Devi Mandiri (@devi)
-* AndSDev (@AndSDev)
+* Dmitry Chestnykh ([@dchest](https://github.com/dchest))
+* Devi Mandiri ([@devi](https://github.com/devi))
+* Kabir R. ([@CMEONE](https://github.com/CMEONE))
+* AndSDev ([@AndSDev](https://github.com/AndSDev))
 
 List of authors of third-party public domain code from which TweetNaCl.js code was derived
 ==========================================================================================

--- a/nacl.js
+++ b/nacl.js
@@ -869,6 +869,9 @@ var crypto_secretbox_KEYBYTES = 32,
     crypto_box_NONCEBYTES = crypto_secretbox_NONCEBYTES,
     crypto_box_ZEROBYTES = crypto_secretbox_ZEROBYTES,
     crypto_box_BOXZEROBYTES = crypto_secretbox_BOXZEROBYTES,
+    crypto_sealedbox_NONCEBYTES = crypto_secretbox_NONCEBYTES,
+    crypto_sealedbox_PUBLICKEYBYTES = 32,
+    crypto_sealedbox_SECRETKEYBYTES = 32,
     crypto_sign_BYTES = 64,
     crypto_sign_PUBLICKEYBYTES = 32,
     crypto_sign_SECRETKEYBYTES = 64,
@@ -911,6 +914,9 @@ nacl.lowlevel = {
   crypto_box_NONCEBYTES: crypto_box_NONCEBYTES,
   crypto_box_ZEROBYTES: crypto_box_ZEROBYTES,
   crypto_box_BOXZEROBYTES: crypto_box_BOXZEROBYTES,
+  crypto_sealedbox_NONCEBYTES: crypto_sealedbox_NONCEBYTES,
+  crypto_sealedbox_PUBLICKEYBYTES: crypto_sealedbox_PUBLICKEYBYTES,
+  crypto_sealedbox_SECRETKEYBYTES: crypto_sealedbox_SECRETKEYBYTES,
   crypto_sign_BYTES: crypto_sign_BYTES,
   crypto_sign_PUBLICKEYBYTES: crypto_sign_PUBLICKEYBYTES,
   crypto_sign_SECRETKEYBYTES: crypto_sign_SECRETKEYBYTES,
@@ -944,6 +950,12 @@ function checkLengths(k, n) {
 function checkBoxLengths(pk, sk) {
   if (pk.length !== crypto_box_PUBLICKEYBYTES) throw new Error('bad public key size');
   if (sk.length !== crypto_box_SECRETKEYBYTES) throw new Error('bad secret key size');
+}
+
+function checkSealedBoxLengths(sk, n, m) {
+  if (sk.length !== crypto_sealedbox_SECRETKEYBYTES) throw new Error('bad secret key size');
+  if (n.length !== crypto_sealedbox_NONCEBYTES) throw new Error('bad nonce size');
+  if (m.length <= crypto_sealedbox_PUBLICKEYBYTES) throw new Error('bad message size');
 }
 
 function checkArrayTypes() {
@@ -1051,6 +1063,33 @@ nacl.box.secretKeyLength = crypto_box_SECRETKEYBYTES;
 nacl.box.sharedKeyLength = crypto_box_BEFORENMBYTES;
 nacl.box.nonceLength = crypto_box_NONCEBYTES;
 nacl.box.overheadLength = nacl.secretbox.overheadLength;
+
+nacl.sealedbox = function(msg, nonce, publicKey) {
+  checkArrayTypes(msg, nonce, publicKey);
+  checkLengths(publicKey, nonce);
+  var ekp = nacl.box.keyPair();
+  var box = nacl.box(msg, nonce, publicKey, ekp.secretKey);
+  for (var i = 0; i < ekp.secretKey.length; i++) ekp.secretKey[i] = 0;
+  var m = new Uint8Array(ekp.publicKey.length + box.length);
+  for (var i = 0; i < ekp.publicKey.length; i++) m[i] = ekp.publicKey[i];
+  for (var i = 0; i < box.length; i++) m[ekp.publicKey.length + i] = box[i];
+  return m;
+}
+
+nacl.sealedbox.open = function(msg, nonce, secretKey) {
+  checkArrayTypes(msg, nonce, secretKey);
+  checkSealedBoxLengths(secretKey, nonce, msg);
+  var epk = new Uint8Array(crypto_box_PUBLICKEYBYTES);
+  for (var i = 0; i < epk.length; i++) epk[i] = msg[i];
+  var m = new Uint8Array(msg.length - crypto_box_PUBLICKEYBYTES);
+  for (var i = 0; i < m.length; i++) m[i] = msg[crypto_box_PUBLICKEYBYTES + i];
+  return nacl.box.open(m, nonce, epk, secretKey);
+}
+
+nacl.sealedbox.publicKeyLength = crypto_sealedbox_PUBLICKEYBYTES;
+nacl.sealedbox.secretKeyLength = crypto_sealedbox_SECRETKEYBYTES;
+nacl.sealedbox.nonceLength = crypto_sealedbox_NONCEBYTES;
+nacl.sealedbox.overheadLength = nacl.box.overheadLength + crypto_sealedbox_PUBLICKEYBYTES;
 
 nacl.sign = function(msg, secretKey) {
   checkArrayTypes(msg, secretKey);


### PR DESCRIPTION
- Adds `nacl.sealedbox(msg, nonce, publicKey)` and `nacl.sealedbox.open(msg, nonce, secretKey)` to `nacl.js` and `nacl-fast.js`
- Adds the following constants to `nacl.js` and `nacl-fast.js`:
```javascript
crypto_sealedbox_NONCEBYTES = crypto_secretbox_NONCEBYTES;
crypto_sealedbox_PUBLICKEYBYTES = 32;
crypto_sealedbox_SECRETKEYBYTES = 32;

nacl.lowlevel.crypto_sealedbox_NONCEBYTES = crypto_sealedbox_NONCEBYTES;
nacl.lowlevel.crypto_sealedbox_PUBLICKEYBYTES = crypto_sealedbox_PUBLICKEYBYTES;
nacl.lowlevel.crypto_sealedbox_SECRETKEYBYTES = crypto_sealedbox_SECRETKEYBYTES;

nacl.sealedbox.publicKeyLength = crypto_sealedbox_PUBLICKEYBYTES;
nacl.sealedbox.secretKeyLength = crypto_sealedbox_SECRETKEYBYTES;
nacl.sealedbox.nonceLength = crypto_sealedbox_NONCEBYTES;
nacl.sealedbox.overheadLength = nacl.box.overheadLength + crypto_sealedbox_PUBLICKEYBYTES;
```
- Adds `checkSealedBoxLengths(sk, n, m)` to check lengths of a secret key, nonce, and message for `nacl.sealedbox.open` to `nacl.js` and `nacl-fast.js`

Although there is a third-party library adding support for sealed boxes, there are a few reasons why I think it would be a good idea to include an implementation directly in `TweetNaCl.js`:
- Third-party library explicitly states that it is officially and completely unmaintained (no issues have been noticed by author since August 2019 with an ignored open issue), this is not great news for a cryptography library
- There is no flexibility in nonces with third-party library as it uses the exact libsodium specification. I currently do not see any reason to follow the nonce part of the specification because the nonce is deterministically generated (from the ephemeral public key and the recipient public key) and could just as well be a `Uint8Array` filled with `0`s (see [libsodium #630](https://github.com/jedisct1/libsodium/issues/630)). It would be better to allow developers to choose the nonce directly for added flexibility, even though my implementation generates ephemeral keys within the scope of the function and zeroes out the secret key after boxing (low risk of reusing the ephemeral key).
- It would be incredibly useful to have sealed boxes as part of the official `TweetNaCl.js` library so that developers do not have to hunt down other libraries and so that companies do not have to add more dependencies to audit. The third-party library is not only just an extra dependency, it is not self-contained and relies on `blakejs` to generate the nonce (unnecessary as described above). 

@dchest Please let me know if you plan to merge this PR. If so, I can write some test cases and add documentation to the `README.md`.

------------------------------------------------------------------------------

    I dedicate any and all copyright interest in this software to the
    public domain. I make this dedication for the benefit of the public at
    large and to the detriment of my heirs and successors. I intend this
    dedication to be an overt act of relinquishment in perpetuity of all
    present and future rights to this software under copyright law.

    Anyone is free to copy, modify, publish, use, compile, sell, or
    distribute this software, either in source code form or as a compiled
    binary, for any purpose, commercial or non-commercial, and by any
    means.
