### PR TITLE
README: add note about performance in Jest tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,6 +457,13 @@ messages per second on a laptop or 60 and 30 messages per second on a smartphone
 per CPU core (with Web Workers you can do these operations in parallel),
 which is good enough for most applications.
 
+### Performance in Jest
+
+When using tweetnacl-js in tests with [Jest](jestjs.io), the
+[extraGlobals](https://jestjs.io/docs/configuration#extraglobals-arraystring)
+configuration variable should include `Math`.
+This avoids a significant performance penalty from the test vm environment.
+
 
 Contributors
 ------------


### PR DESCRIPTION
tweetnacl-js is noticeably slow in Jest tests, which can be fixed by simply configuring the test vm to include the `Math` object. Took us a while to figure out, maybe this will save someone else the trip :)