### PR TITLE
Point notable users section to wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,9 +479,4 @@ Third-party libraries based on TweetNaCl.js
 Who uses it
 -----------
 
-Some notable users of TweetNaCl.js:
-
-* [GitHub](https://github.com)
-* [MEGA](https://github.com/meganz/webclient)
-* [Stellar](https://www.stellar.org/)
-* [Solana](https://solana.com/)
+Some notable users of TweetNaCl.js are listed on the [associated wiki page](https://github.com/dchest/tweetnacl-js/wiki/Who-uses-TweetNaCl.js).

--- a/README.md
+++ b/README.md
@@ -484,4 +484,4 @@ Some notable users of TweetNaCl.js:
 * [GitHub](https://github.com)
 * [MEGA](https://github.com/meganz/webclient)
 * [Stellar](https://www.stellar.org/)
-* [miniLock](https://github.com/kaepora/miniLock)
+* [Solana](https://solana.com/)


### PR DESCRIPTION
Since miniLock source code now returns a 404 error, I figured it might be good to replace it with another project in the notable users section. Solana is one of the top ten cryptocurrencies by market cap (for reference, Stellar is ranked 30th and is also included in notable users), and they use TweetNaCl.js in their [web3 SDK](https://github.com/solana-labs/solana-web3.js). @dchest please let me know what you think about replacing miniLock with Solana in notable users.

------------------------------------------------------------------------------

    I dedicate any and all copyright interest in this software to the
    public domain. I make this dedication for the benefit of the public at
    large and to the detriment of my heirs and successors. I intend this
    dedication to be an overt act of relinquishment in perpetuity of all
    present and future rights to this software under copyright law.

    Anyone is free to copy, modify, publish, use, compile, sell, or
    distribute this software, either in source code form or as a compiled
    binary, for any purpose, commercial or non-commercial, and by any
    means.
