### PR TITLE
Add improvements for links

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,5 @@
 {
-  'env': {                           // http://eslint.org/docs/user-guide/configuring.html#specifying-environments
+  'env': {                           // https://eslint.org/docs/user-guide/configuring.html#specifying-environments
     'node': true,
     'browser': true,
     'shared-node-browser': true
@@ -15,134 +15,134 @@
     /**
      * Strict mode
      */
-    'strict': 0,          // http://eslint.org/docs/rules/strict
+    'strict': 0,          // https://eslint.org/docs/rules/strict
 
     /**
      * Variables
      */
-    'no-shadow': 2,                  // http://eslint.org/docs/rules/no-shadow
-    'no-shadow-restricted-names': 2, // http://eslint.org/docs/rules/no-shadow-restricted-names
-    'no-undef': 2,                   // http://eslint.org/docs/rules/no-undef
-    'no-unused-vars': [2, {          // http://eslint.org/docs/rules/no-unused-vars
+    'no-shadow': 2,                  // https://eslint.org/docs/rules/no-shadow
+    'no-shadow-restricted-names': 2, // https://eslint.org/docs/rules/no-shadow-restricted-names
+    'no-undef': 2,                   // https://eslint.org/docs/rules/no-undef
+    'no-unused-vars': [2, {          // https://eslint.org/docs/rules/no-unused-vars
       'vars': 'local',
       'args': 'after-used'
     }],
-    'no-use-before-define': 2,       // http://eslint.org/docs/rules/no-use-before-define
+    'no-use-before-define': 2,       // https://eslint.org/docs/rules/no-use-before-define
 
     /**
      * Possible errors
      */
-    'comma-dangle': [2, 'never'],    // http://eslint.org/docs/rules/comma-dangle
-    'no-cond-assign': 0, // http://eslint.org/docs/rules/no-cond-assign
-    'no-console': 0,                 // http://eslint.org/docs/rules/no-console
-    'no-debugger': 1,                // http://eslint.org/docs/rules/no-debugger
-    'no-alert': 1,                   // http://eslint.org/docs/rules/no-alert
-    'no-constant-condition': 1,      // http://eslint.org/docs/rules/no-constant-condition
-    'no-dupe-keys': 2,               // http://eslint.org/docs/rules/no-dupe-keys
-    'no-duplicate-case': 2,          // http://eslint.org/docs/rules/no-duplicate-case
-    'no-empty': 2,                   // http://eslint.org/docs/rules/no-empty
-    'no-ex-assign': 2,               // http://eslint.org/docs/rules/no-ex-assign
-    'no-extra-boolean-cast': 0,      // http://eslint.org/docs/rules/no-extra-boolean-cast
-    'no-extra-semi': 2,              // http://eslint.org/docs/rules/no-extra-semi
-    'no-func-assign': 2,             // http://eslint.org/docs/rules/no-func-assign
-    'no-inner-declarations': 2,      // http://eslint.org/docs/rules/no-inner-declarations
-    'no-invalid-regexp': 2,          // http://eslint.org/docs/rules/no-invalid-regexp
-    'no-irregular-whitespace': 2,    // http://eslint.org/docs/rules/no-irregular-whitespace
-    'no-obj-calls': 2,               // http://eslint.org/docs/rules/no-obj-calls
-    'no-sparse-arrays': 2,           // http://eslint.org/docs/rules/no-sparse-arrays
-    'no-unreachable': 2,             // http://eslint.org/docs/rules/no-unreachable
-    'use-isnan': 2,                  // http://eslint.org/docs/rules/use-isnan
-    'block-scoped-var': 2,           // http://eslint.org/docs/rules/block-scoped-var
+    'comma-dangle': [2, 'never'],    // https://eslint.org/docs/rules/comma-dangle
+    'no-cond-assign': 0, // https://eslint.org/docs/rules/no-cond-assign
+    'no-console': 0,                 // https://eslint.org/docs/rules/no-console
+    'no-debugger': 1,                // https://eslint.org/docs/rules/no-debugger
+    'no-alert': 1,                   // https://eslint.org/docs/rules/no-alert
+    'no-constant-condition': 1,      // https://eslint.org/docs/rules/no-constant-condition
+    'no-dupe-keys': 2,               // https://eslint.org/docs/rules/no-dupe-keys
+    'no-duplicate-case': 2,          // https://eslint.org/docs/rules/no-duplicate-case
+    'no-empty': 2,                   // https://eslint.org/docs/rules/no-empty
+    'no-ex-assign': 2,               // https://eslint.org/docs/rules/no-ex-assign
+    'no-extra-boolean-cast': 0,      // https://eslint.org/docs/rules/no-extra-boolean-cast
+    'no-extra-semi': 2,              // https://eslint.org/docs/rules/no-extra-semi
+    'no-func-assign': 2,             // https://eslint.org/docs/rules/no-func-assign
+    'no-inner-declarations': 2,      // https://eslint.org/docs/rules/no-inner-declarations
+    'no-invalid-regexp': 2,          // https://eslint.org/docs/rules/no-invalid-regexp
+    'no-irregular-whitespace': 2,    // https://eslint.org/docs/rules/no-irregular-whitespace
+    'no-obj-calls': 2,               // https://eslint.org/docs/rules/no-obj-calls
+    'no-sparse-arrays': 2,           // https://eslint.org/docs/rules/no-sparse-arrays
+    'no-unreachable': 2,             // https://eslint.org/docs/rules/no-unreachable
+    'use-isnan': 2,                  // https://eslint.org/docs/rules/use-isnan
+    'block-scoped-var': 2,           // https://eslint.org/docs/rules/block-scoped-var
 
     /**
      * Best practices
      */
-    'consistent-return': 2,          // http://eslint.org/docs/rules/consistent-return
-    'curly': 0,      // http://eslint.org/docs/rules/curly
-    'default-case': 2,               // http://eslint.org/docs/rules/default-case
-    'dot-notation': [2, {            // http://eslint.org/docs/rules/dot-notation
+    'consistent-return': 2,          // https://eslint.org/docs/rules/consistent-return
+    'curly': 0,      // https://eslint.org/docs/rules/curly
+    'default-case': 2,               // https://eslint.org/docs/rules/default-case
+    'dot-notation': [2, {            // https://eslint.org/docs/rules/dot-notation
       'allowKeywords': true
     }],
-    'eqeqeq': 2,                     // http://eslint.org/docs/rules/eqeqeq
-    'guard-for-in': 2,               // http://eslint.org/docs/rules/guard-for-in
-    'no-caller': 2,                  // http://eslint.org/docs/rules/no-caller
-    'no-else-return': 0,             // http://eslint.org/docs/rules/no-else-return
-    'no-eq-null': 2,                 // http://eslint.org/docs/rules/no-eq-null
-    'no-eval': 2,                    // http://eslint.org/docs/rules/no-eval
-    'no-extend-native': 2,           // http://eslint.org/docs/rules/no-extend-native
-    'no-extra-bind': 2,              // http://eslint.org/docs/rules/no-extra-bind
-    'no-fallthrough': 2,             // http://eslint.org/docs/rules/no-fallthrough
-    'no-floating-decimal': 2,        // http://eslint.org/docs/rules/no-floating-decimal
-    'no-implied-eval': 2,            // http://eslint.org/docs/rules/no-implied-eval
-    'no-lone-blocks': 2,             // http://eslint.org/docs/rules/no-lone-blocks
-    'no-loop-func': 2,               // http://eslint.org/docs/rules/no-loop-func
-    'no-multi-str': 2,               // http://eslint.org/docs/rules/no-multi-str
-    'no-native-reassign': 2,         // http://eslint.org/docs/rules/no-native-reassign
-    'no-new': 2,                     // http://eslint.org/docs/rules/no-new
-    'no-new-func': 2,                // http://eslint.org/docs/rules/no-new-func
-    'no-new-wrappers': 2,            // http://eslint.org/docs/rules/no-new-wrappers
-    'no-octal': 2,                   // http://eslint.org/docs/rules/no-octal
-    'no-octal-escape': 2,            // http://eslint.org/docs/rules/no-octal-escape
-    'no-param-reassign': 0,          // http://eslint.org/docs/rules/no-param-reassign
-    'no-proto': 2,                   // http://eslint.org/docs/rules/no-proto
-    'no-redeclare': 2,               // http://eslint.org/docs/rules/no-redeclare
-    'no-return-assign': 2,           // http://eslint.org/docs/rules/no-return-assign
-    'no-script-url': 2,              // http://eslint.org/docs/rules/no-script-url
-    'no-self-compare': 2,            // http://eslint.org/docs/rules/no-self-compare
-    'no-sequences': 2,               // http://eslint.org/docs/rules/no-sequences
-    'no-throw-literal': 2,           // http://eslint.org/docs/rules/no-throw-literal
-    'no-with': 2,                    // http://eslint.org/docs/rules/no-with
-    'radix': 2,                      // http://eslint.org/docs/rules/radix
-    'vars-on-top': 0,                // http://eslint.org/docs/rules/vars-on-top
-    'wrap-iife': [2, 'any'],         // http://eslint.org/docs/rules/wrap-iife
-    'yoda': 2,                       // http://eslint.org/docs/rules/yoda
+    'eqeqeq': 2,                     // https://eslint.org/docs/rules/eqeqeq
+    'guard-for-in': 2,               // https://eslint.org/docs/rules/guard-for-in
+    'no-caller': 2,                  // https://eslint.org/docs/rules/no-caller
+    'no-else-return': 0,             // https://eslint.org/docs/rules/no-else-return
+    'no-eq-null': 2,                 // https://eslint.org/docs/rules/no-eq-null
+    'no-eval': 2,                    // https://eslint.org/docs/rules/no-eval
+    'no-extend-native': 2,           // https://eslint.org/docs/rules/no-extend-native
+    'no-extra-bind': 2,              // https://eslint.org/docs/rules/no-extra-bind
+    'no-fallthrough': 2,             // https://eslint.org/docs/rules/no-fallthrough
+    'no-floating-decimal': 2,        // https://eslint.org/docs/rules/no-floating-decimal
+    'no-implied-eval': 2,            // https://eslint.org/docs/rules/no-implied-eval
+    'no-lone-blocks': 2,             // https://eslint.org/docs/rules/no-lone-blocks
+    'no-loop-func': 2,               // https://eslint.org/docs/rules/no-loop-func
+    'no-multi-str': 2,               // https://eslint.org/docs/rules/no-multi-str
+    'no-native-reassign': 2,         // https://eslint.org/docs/rules/no-native-reassign
+    'no-new': 2,                     // https://eslint.org/docs/rules/no-new
+    'no-new-func': 2,                // https://eslint.org/docs/rules/no-new-func
+    'no-new-wrappers': 2,            // https://eslint.org/docs/rules/no-new-wrappers
+    'no-octal': 2,                   // https://eslint.org/docs/rules/no-octal
+    'no-octal-escape': 2,            // https://eslint.org/docs/rules/no-octal-escape
+    'no-param-reassign': 0,          // https://eslint.org/docs/rules/no-param-reassign
+    'no-proto': 2,                   // https://eslint.org/docs/rules/no-proto
+    'no-redeclare': 2,               // https://eslint.org/docs/rules/no-redeclare
+    'no-return-assign': 2,           // https://eslint.org/docs/rules/no-return-assign
+    'no-script-url': 2,              // https://eslint.org/docs/rules/no-script-url
+    'no-self-compare': 2,            // https://eslint.org/docs/rules/no-self-compare
+    'no-sequences': 2,               // https://eslint.org/docs/rules/no-sequences
+    'no-throw-literal': 2,           // https://eslint.org/docs/rules/no-throw-literal
+    'no-with': 2,                    // https://eslint.org/docs/rules/no-with
+    'radix': 2,                      // https://eslint.org/docs/rules/radix
+    'vars-on-top': 0,                // https://eslint.org/docs/rules/vars-on-top
+    'wrap-iife': [2, 'any'],         // https://eslint.org/docs/rules/wrap-iife
+    'yoda': 2,                       // https://eslint.org/docs/rules/yoda
 
     /**
      * Style
      */
-    'indent': 0,                // http://eslint.org/docs/rules/indent
+    'indent': 0,                // https://eslint.org/docs/rules/indent
     'brace-style': [
-      2,               // http://eslint.org/docs/rules/brace-style
+      2,               // https://eslint.org/docs/rules/brace-style
       '1tbs', {
         'allowSingleLine': true
       }
     ],
     'quotes': [
-      2, 'single', 'avoid-escape'    // http://eslint.org/docs/rules/quotes
+      2, 'single', 'avoid-escape'    // https://eslint.org/docs/rules/quotes
     ],
     'camelcase': 0,
     'comma-spacing': 0,
-    'comma-style': [2, 'last'],      // http://eslint.org/docs/rules/comma-style
-    'eol-last': 2,                   // http://eslint.org/docs/rules/eol-last
-    'func-names': 0,                 // http://eslint.org/docs/rules/func-names
-    'key-spacing': [2, {             // http://eslint.org/docs/rules/key-spacing
+    'comma-style': [2, 'last'],      // https://eslint.org/docs/rules/comma-style
+    'eol-last': 2,                   // https://eslint.org/docs/rules/eol-last
+    'func-names': 0,                 // https://eslint.org/docs/rules/func-names
+    'key-spacing': [2, {             // https://eslint.org/docs/rules/key-spacing
       'beforeColon': false,
       'afterColon': true
     }],
-    'new-cap': [0, {                 // http://eslint.org/docs/rules/new-cap
+    'new-cap': [0, {                 // https://eslint.org/docs/rules/new-cap
       'newIsCap': true
     }],
-    'no-multiple-empty-lines': [2, { // http://eslint.org/docs/rules/no-multiple-empty-lines
+    'no-multiple-empty-lines': [2, { // https://eslint.org/docs/rules/no-multiple-empty-lines
       'max': 2
     }],
-    'no-nested-ternary': 2,          // http://eslint.org/docs/rules/no-nested-ternary
-    'no-new-object': 2,              // http://eslint.org/docs/rules/no-new-object
-    'no-spaced-func': 2,             // http://eslint.org/docs/rules/no-spaced-func
-    'no-trailing-spaces': 2,         // http://eslint.org/docs/rules/no-trailing-spaces
-    'no-extra-parens': [2, 'functions'], // http://eslint.org/docs/rules/no-extra-parens
-    'no-underscore-dangle': 0,       // http://eslint.org/docs/rules/no-underscore-dangle
-    'one-var': 0,         // http://eslint.org/docs/rules/one-var
-    'padded-blocks': 0,   // http://eslint.org/docs/rules/padded-blocks
-    'semi': [2, 'always'],           // http://eslint.org/docs/rules/semi
-    'semi-spacing': [2, {            // http://eslint.org/docs/rules/semi-spacing
+    'no-nested-ternary': 2,          // https://eslint.org/docs/rules/no-nested-ternary
+    'no-new-object': 2,              // https://eslint.org/docs/rules/no-new-object
+    'no-spaced-func': 2,             // https://eslint.org/docs/rules/no-spaced-func
+    'no-trailing-spaces': 2,         // https://eslint.org/docs/rules/no-trailing-spaces
+    'no-extra-parens': [2, 'functions'], // https://eslint.org/docs/rules/no-extra-parens
+    'no-underscore-dangle': 0,       // https://eslint.org/docs/rules/no-underscore-dangle
+    'one-var': 0,         // https://eslint.org/docs/rules/one-var
+    'padded-blocks': 0,   // https://eslint.org/docs/rules/padded-blocks
+    'semi': [2, 'always'],           // https://eslint.org/docs/rules/semi
+    'semi-spacing': [2, {            // https://eslint.org/docs/rules/semi-spacing
       'before': false,
       'after': true
     }],
-    'space-after-keywords': 0,       // http://eslint.org/docs/rules/space-after-keywords
-    'space-before-blocks': 2,        // http://eslint.org/docs/rules/space-before-blocks
-    'space-before-function-paren': [2, 'never'], // http://eslint.org/docs/rules/space-before-function-paren
-    'space-infix-ops': 0,            // http://eslint.org/docs/rules/space-infix-ops
-    'spaced-comment': [2, 'always',  {// http://eslint.org/docs/rules/spaced-comment
+    'space-after-keywords': 0,       // https://eslint.org/docs/rules/space-after-keywords
+    'space-before-blocks': 2,        // https://eslint.org/docs/rules/space-before-blocks
+    'space-before-function-paren': [2, 'never'], // https://eslint.org/docs/rules/space-before-function-paren
+    'space-infix-ops': 0,            // https://eslint.org/docs/rules/space-infix-ops
+    'spaced-comment': [2, 'always',  {// https://eslint.org/docs/rules/spaced-comment
       'exceptions': ['-', '+'],
       'markers': ['=', '!', 'global', 'TODO', 'XXX', 'BUG']           // space here to support sprockets directives
     }],

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -3,25 +3,25 @@ List of TweetNaCl.js authors
 
     Format: Name (GitHub username or URL)
 
-* Dmitry Chestnykh (@dchest)
-* Devi Mandiri (@devi)
-* AndSDev (@AndSDev)
+* Dmitry Chestnykh ([@dchest](https://github.com/dchest))
+* Devi Mandiri ([@devi](https://github.com/devi))
+* AndSDev ([@AndSDev](https://github.com/AndSDev))
 
 List of authors of third-party public domain code from which TweetNaCl.js code was derived
 ==========================================================================================
 
-[TweetNaCl](http://tweetnacl.cr.yp.to/)
+[TweetNaCl](https://tweetnacl.cr.yp.to/)
 --------------------------------------
 
 * Bernard van Gastel
-* Daniel J. Bernstein <http://cr.yp.to/djb.html>
-* Peter Schwabe <http://www.cryptojedi.org/users/peter/>
-* Sjaak Smetsers <http://www.cs.ru.nl/~sjakie/>
-* Tanja Lange <http://hyperelliptic.org/tanja>
+* Daniel J. Bernstein ([cr.yp.to/djb.html](https://cr.yp.to/djb.html))
+* Peter Schwabe ([cryptojedi.org/peter/](https://cryptojedi.org/peter/))
+* Sjaak Smetsers ([cs.ru.nl/~sjakie/](https://cs.ru.nl/~sjakie/))
+* Tanja Lange ([hyperelliptic.org/tanja](https://hyperelliptic.org/tanja))
 * Wesley Janssen
 
 
 [Poly1305-donna](https://github.com/floodyberry/poly1305-donna)
 --------------------------------------------------------------
 
-* Andrew Moon (@floodyberry)
+* Andrew Moon ([@floodyberry](https://github.com/floodyberry))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ incorrect signatures.
 
 This only affects signing, not verification.
 
-Thanks to @valerini on GitHub for finding and reporting the bug.
+Thanks to [@valerini](https://github.com/valerini) on GitHub for finding and reporting the bug.
 
 
 v1.0.2
@@ -79,7 +79,7 @@ v0.14.5
 v0.14.4
 -------
 
-* Added TypeScript type definitions (contributed by @AndSDev).
+* Added TypeScript type definitions (contributed by [@AndSDev](https://github.com/AndSDev)).
 * Improved benchmarking code.
 
 
@@ -88,14 +88,14 @@ v0.14.3
 
 Fixed a bug in the fast version of Poly1305 and brought it back.
 
-Thanks to @floodyberry for promptly responding and fixing the original C code:
+Thanks to [@floodyberry](https://github.com/floodyberry) for promptly responding and fixing the original C code:
 
 > "The issue was not properly detecting if st->h was >= 2^130 - 5, coupled with
 > [testing mistake] not catching the failure. The chance of the bug affecting
 > anything in the real world is essentially zero luckily, but it's good to have
 > it fixed."
 
-https://github.com/floodyberry/poly1305-donna/issues/2#issuecomment-202698577
+[github.com/floodyberry/poly1305-donna/issues/2#issuecomment-202698577](https://github.com/floodyberry/poly1305-donna/issues/2#issuecomment-202698577)
 
 
 v0.14.2
@@ -122,7 +122,7 @@ v0.14.0
       nacl.util.encodeBase64
 
   If want to continue using them, you can include
-  <https://github.com/dchest/tweetnacl-util-js> package:
+  [github.com/dchest/tweetnacl-util-js](https://github.com/dchest/tweetnacl-util-js) package:
 
       <script src="nacl.min.js"></script>
       <script src="nacl-util.min.js"></script>
@@ -223,7 +223,7 @@ v0.11.0
 
 * Implement `nacl.sign.keyPair.fromSeed` to enable creation of sign key pairs
   deterministically from a 32-byte seed. (It behaves like
-  [libsodium's](http://doc.libsodium.org/public-key_cryptography/public-key_signatures.html)
+  [libsodium's](https://doc.libsodium.org/public-key_cryptography/public-key_signatures)
   `crypto_sign_seed_keypair`: the seed becomes a secret part of the secret key.)
 
 * Fast version now has an improved hash implementation that is 2x-5x faster.

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 
 If your contribution is not trivial (not a typo fix, etc.), we can only accept
 it if you dedicate your copyright for the contribution to the public domain.
-Make sure you understand what it means (see http://unlicense.org/)! If you
+Make sure you understand what it means (see [unlicense.org](https://unlicense.org/))! If you
 agree, please add yourself to AUTHORS.md file, and include the following text
 to your pull request description or a comment in it:
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 TweetNaCl.js
 ============
 
-Port of [TweetNaCl](http://tweetnacl.cr.yp.to) / [NaCl](http://nacl.cr.yp.to/)
+Port of [TweetNaCl](https://tweetnacl.cr.yp.to) / [NaCl](https://nacl.cr.yp.to/)
 to JavaScript for modern browsers and Node.js. Public domain.
 
 [![Build Status](https://travis-ci.org/dchest/tweetnacl-js.svg?branch=master)
@@ -231,7 +231,7 @@ Length of group element in bytes.
 
 ### Signatures
 
-Implements [ed25519](http://ed25519.cr.yp.to).
+Implements [ed25519](https://ed25519.cr.yp.to).
 
 #### nacl.sign.keyPair()
 
@@ -471,7 +471,7 @@ Third-party libraries based on TweetNaCl.js
 * [forward-secrecy](https://github.com/alax/forward-secrecy) — Axolotl ratchet implementation
 * [nacl-stream](https://github.com/dchest/nacl-stream-js) - streaming encryption
 * [ristretto255-js](https://github.com/calibra/ristretto255-js) — implementation of the [ristretto255 group](https://ristretto.group/)
-* [tweetnacl-auth-js](https://github.com/dchest/tweetnacl-auth-js) — implementation of [`crypto_auth`](http://nacl.cr.yp.to/auth.html)
+* [tweetnacl-auth-js](https://github.com/dchest/tweetnacl-auth-js) — implementation of [`crypto_auth`](https://nacl.cr.yp.to/auth.html)
 * [tweetnacl-js-sealed-box](https://github.com/TogaTech/tweetnacl-js-sealed-box) — fork that adds [`sealed boxes`](https://download.libsodium.org/doc/public-key_cryptography/sealed_boxes.html)
 * [ed2curve](https://github.com/dchest/ed2curve-js) — convert Ed25519 signing key pair to X25519 boxes key pair
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ to JavaScript for modern browsers and Node.js. Public domain.
 [![Build Status](https://travis-ci.org/dchest/tweetnacl-js.svg?branch=master)
 ](https://travis-ci.org/dchest/tweetnacl-js)
 
-Demo: <https://dchest.github.io/tweetnacl-js/>
+Demo: [dchest.github.io/tweetnacl-js/](https://dchest.github.io/tweetnacl-js/)
 
 Documentation
 =============
@@ -88,7 +88,7 @@ Usage
 
 All API functions accept and return bytes as `Uint8Array`s.  If you need to
 encode or decode strings, use functions from
-<https://github.com/dchest/tweetnacl-util-js> or one of the more robust codec
+[github.com/dchest/tweetnacl-util-js](https://github.com/dchest/tweetnacl-util-js) or one of the more robust codec
 packages.
 
 In Node.js v4 and later `Buffer` objects are backed by `Uint8Array`s, so you

--- a/nacl-fast.js
+++ b/nacl-fast.js
@@ -5,7 +5,7 @@
 // Public domain.
 //
 // Implementation derived from TweetNaCl version 20140427.
-// See for details: http://tweetnacl.cr.yp.to/
+// See for details: https://tweetnacl.cr.yp.to/
 
 var gf = function(init) {
   var i, r = new Float64Array(16);

--- a/nacl.js
+++ b/nacl.js
@@ -5,7 +5,7 @@
 // Public domain.
 //
 // Implementation derived from TweetNaCl version 20140427.
-// See for details: http://tweetnacl.cr.yp.to/
+// See for details: https://tweetnacl.cr.yp.to/
 
 var u64 = function(h, l) { this.hi = h|0 >>> 0; this.lo = l|0 >>> 0; };
 var gf = function(init) {


### PR DESCRIPTION
This PR brings minor improvements for the links listed throughout this repository:
- All links that support HTTPS have `https://` instead of `http://` (this is a cryptography library, after all!) with the exception of the link in `LICENSE.md` which stays at `http://` to remain consistent with the license format on [unlicense.org](https://unlicense.org/)
- All mentions of GitHub users now have links (for instance, @dchest would now be [@dchest](https://github.com/dchest))
- Standalone links have been shortened through hiding the `https://` portion (for instance, [https://dchest.github.io/tweetnacl-js/](https://dchest.github.io/tweetnacl-js/) would now be [dchest.github.io/tweetnacl-js/](https://dchest.github.io/tweetnacl-js/))

------------------------------------------------------------------------------

    I dedicate any and all copyright interest in this software to the
    public domain. I make this dedication for the benefit of the public at
    large and to the detriment of my heirs and successors. I intend this
    dedication to be an overt act of relinquishment in perpetuity of all
    present and future rights to this software under copyright law.

    Anyone is free to copy, modify, publish, use, compile, sell, or
    distribute this software, either in source code form or as a compiled
    binary, for any purpose, commercial or non-commercial, and by any
    means.
